### PR TITLE
Fix memory leak

### DIFF
--- a/src/Noise.cpp
+++ b/src/Noise.cpp
@@ -50,6 +50,10 @@ struct Noise : Module {
 		configOutput(CNOISE_OUTPUT, "Colored Noise");
 	}
 
+	~Noise() override {
+		delete VR;
+	}
+
 	void process(const ProcessArgs& args) override;
 
 


### PR DESCRIPTION
Detected by valgrind, `VR` is allocated on init but never deleted.

```
==890428== 4 bytes in 1 blocks are definitely lost in loss record 5 of 3,615
==890428==    at 0x6E8E013: operator new(unsigned long) (in /usr/libexec/valgrind/vgpreload_memcheck-amd64-linux.so)
==890428==    by 0x1E36D19: MSMNoise::MSMNoise() (Noise.cpp:42)
==890428==    by 0x1E38319: rack::CardinalPluginModel<MSMNoise, MSMNoiseWidget>::createModule() (helpers.hpp:52)
==890428==    by 0x6B39D9: CardinalDISTRHO::CardinalUI::uiIdle() (CardinalUI.cpp:484)
==890428==    by 0x6CA0FA: CardinalDISTRHO::UIExporter::plugin_idle() (DistrhoUIInternal.hpp:248)
==890428==    by 0x6C6368: CardinalDISTRHO::runSelfTests() (DistrhoPluginJACK.cpp:861)
==890428==    by 0x6C65AC: main (DistrhoPluginJACK.cpp:963)
==890428== 
```